### PR TITLE
Shows how to verify signed callbacks and check payload

### DIFF
--- a/messages/verify_signed_webhooks.py
+++ b/messages/verify_signed_webhooks.py
@@ -1,0 +1,73 @@
+import jwt
+import hashlib
+import json
+import os
+from flask import Flask, request, jsonify
+from os.path import join, dirname
+from dotenv import load_dotenv
+from pprint import pprint
+
+#Load the environment
+envpath = join(dirname(__file__),'../.env')
+load_dotenv(envpath)
+
+app = Flask(__name__)
+
+port = os.getenv('PORT')
+api_key = os.getenv('NEXMO_API_KEY')
+sig_secret = os.getenv('NEXMO_SIG_SECRET')
+verify_webhooks = True # Set to False if you don't want to verify webhooks
+error_message = ''
+
+def verify_webhook(request):
+    global error_message
+
+    # Need token after 'Bearer'
+    parts = request.headers['authorization'].split() 
+    token = parts[1].strip()
+
+    # Verify request
+    decoded = jwt.decode(token, sig_secret, algorithms='HS256')
+    if decoded['api_key'] == api_key:
+        print('Valid callback signature')
+        # we can continue to check payload 
+    else:
+        error_message = 'Warning: Invalid callback signature!'
+        print(error_message)
+        return False
+    
+    # Obtain transmitted payload hash
+    payload_hash = decoded["payload_hash"]
+
+    # generate hash of request payload
+    payload = request.data # Obtains request data as binary string
+    h = hashlib.sha256(payload) # requires binary string
+    hd = h.hexdigest() # Use hexdigest() and NOT digest()
+
+    # Check the payload hash matches the one we created ourselves from request data
+    if (hd != payload_hash):
+        error_message = "WARNING: payload may have been tampered with in-transit"
+        return False
+    print("Verified payload")
+    return True 
+
+@app.route("/webhooks/inbound", methods=['POST'])
+def inbound():
+    if verify_webhooks:
+        if verify_webhook(request):
+            data = request.get_json()
+            pprint(data) 
+            return (jsonify(data))
+        else:
+            error_obj = {'error_message': error_message, 'error_code': 401}
+            error = json.dumps(error_obj)
+            return (error, 401)
+
+@app.route("/webhooks/status", methods=['POST'])
+def status():
+    data = request.get_json()
+    return (jsonify(data))
+
+if __name__ == '__main__':
+    print("Running locally")
+    app.run(host="localhost", port=port)

--- a/messages/verify_signed_webhooks.py
+++ b/messages/verify_signed_webhooks.py
@@ -16,7 +16,6 @@ app = Flask(__name__)
 port = os.getenv('PORT')
 api_key = os.getenv('NEXMO_API_KEY') # there may be multiple api_key/sig_secret pairs
 sig_secret = os.getenv('NEXMO_SIG_SECRET')
-verify_webhooks = True # Set to False if you don't want to verify webhooks
 
 @app.route("/webhooks/inbound", methods=['POST'])
 def inbound():

--- a/messages/verify_signed_webhooks.py
+++ b/messages/verify_signed_webhooks.py
@@ -24,7 +24,6 @@ def inbound():
     token = parts[1].strip()
 
     # Extract api_key from token payload
-    # So we can find matching sig secret
     k = jwt.decode(token, verify=False)["api_key"]
     # Use k to look up corresponding sig secret
     


### PR DESCRIPTION
## Summary

Code to verify signed callbacks (and check payload). 

## Status

Tested with WhatsApp inbound messages via Sandbox.

## Description

An initial version of some code to verify signed callbacks for **inbound messages**. 

This code does the following:

1. It extracts API key from JWT payload so you can work out which corresponding sig secret to use. This is useful where a customer has multiple accounts.
2. It verifies the JWT using the sig secret. PyJWT verifies by default as part of `decode()`. In the case where verification fails an exception is generated and caught, and 401 returned.
3. It hashes the request payload using SHA-256 and verifies that this matches `payload_hash` in the JWT signature of the callback. You would only need to do this if using HTTP rather than HTTPS.

## Testing

You need your Nexmo API key and also your Signature Secret from the Nexmo Dashboard. Also, only works at time of writing with the Messages sandbox as far as I know. 

## TODO

- [x] Handle the case where you have multiple api keys.
- [x] Handle correct verification of the JWT
- [x] Exception handling